### PR TITLE
[tail-file] Fix README and .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,4 +10,4 @@ coverage
 .tap-output
 Jenkinsfile
 tools
-test/memory-usage
+test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/logdna/tail-file-node/badge.svg?branch=master)](https://coveralls.io/github/logdna/tail-file-node?branch=master)
+
 # TailFile
 
 At LogDNA, consuming log files and making them searchable is what we do!
@@ -220,7 +222,7 @@ stream, so it may also emit these events.  The most common ones are `close`
   * Any additional key-value options get passed to the [`Readable`][] superclass
     constructor of `TailFile`
 * Throws: [`<TypeError>`][] if parameter validation fails
-* Returns: `TailFile`, which is a [`Readable`][Readable] stream
+* Returns: `TailFile`, which is a [`Readable`][] stream
 
 Instantiating `TailFile` will return a readable stream, but nothing will happen
 until [`start()`](#start) is called.  After that, follow node's standard procedure to


### PR DESCRIPTION
**fix: Add test to .npmignore**

The test files bulk up the package and erroneously report
it has having 70% "shell" scripting due to the large
shell script that is part of the test suite.  All of this
should be excluded from the package.

Semver: patch

---

**fix: Invalid README link, and add code coverage badge**

There was a bad link in the README and this also adds
a coveralls.io badge to show our 100% coverage.

Semver: patch
