### PR TITLE
fix: CI release stage be aware of existing branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,7 @@ pipeline {
       steps {
         sh 'mkdir -p .npm'
 
-        sh "git checkout -b ${GIT_BRANCH} origin/${GIT_BRANCH}"
+        sh "git checkout -B ${GIT_BRANCH} origin/${GIT_BRANCH}"
 
         versioner(
           token: "${GITHUB_PACKAGES_TOKEN}"


### PR DESCRIPTION
There have been CI errors where the main branch
already exists and the stage fails. By using -B
this will switch to that branch if it exists
already.

Semver: patch