### PR TITLE
feat: startPos allows specifying the position to tail from

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,11 @@ stream, so it may also emit these events.  The most common ones are `close`
   * `readStreamOpts` [`<Object>`][] - Options to pass to the
     [`fs.createReadStream`][createReadStream] function. This is used for reading bytes
     that have been added to `filename` between every poll.
+  * `startPos` [`<Number>`][] - An integer representing the inital read position in
+    the file. Useful for reading from `0`. **Default:** `null` (start tailing from EOF)
   * Any additional key-value options get passed to the [`Readable`][] superclass
     constructor of `TailFile`
-* Throws: [`<TypeError>`][] if parameter validation fails
+* Throws: [`<TypeError>`][]|[`<RangeError>`][] if parameter validation fails
 * Returns: `TailFile`, which is a [`Readable`][] stream
 
 Instantiating `TailFile` will return a readable stream, but nothing will happen
@@ -303,6 +305,7 @@ stream almost immediately upon creation.
 [`<Object>`]: https://mdn.io/object
 [`<String>`]: https://mdn.io/string
 [`<TypeError>`]: https://mdn.io/TypeError
+[`<RangeError>`]: https://mdn.io/RangeError
 [`<Error>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 [`Readable`]: https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_class_stream_readable
 [`FileHandle`]: https://nodejs.org/dist/latest-v12.x/docs/api/fs.html#fs_class_filehandle

--- a/lib/tail-file.js
+++ b/lib/tail-file.js
@@ -28,6 +28,7 @@ class TailFile extends Readable {
     , pollFailureRetryMs
     , maxPollFailures
     , readStreamOpts
+    , startPos
     , ...superOpts
     } = opts
 
@@ -68,6 +69,24 @@ class TailFile extends Readable {
       }
       throw err
     }
+    if (startPos !== null && startPos !== undefined) {
+      if (typeof startPos !== 'number') {
+        const err = new TypeError('startPos must be an integer >= 0')
+        err.code = 'ESTARTPOS'
+        err.meta = {
+          got: typeof startPos
+        }
+        throw err
+      }
+      if (startPos < 0 || !Number.isInteger(startPos)) {
+        const err = new RangeError('startPos must be an integer >= 0')
+        err.code = 'ESTARTPOS'
+        err.meta = {
+          got: startPos
+        }
+        throw err
+      }
+    }
 
     super(superOpts)
 
@@ -77,7 +96,9 @@ class TailFile extends Readable {
     this[kPollFailureRetryMs] = pollFailureRetryMs || 200
     this[kMaxPollFailures] = maxPollFailures || 10
     this[kPollFailureCount] = 0
-    this[kStartPos] = null
+    this[kStartPos] = startPos >= 0
+      ? startPos
+      : null
     this[kStream] = null
     this[kFileHandle] = null
     this[kPollTimer] = null
@@ -144,10 +165,11 @@ class TailFile extends Readable {
       const eof = stats.size
       let fileHasChanged = false
 
+      if (!this[kInode]) this[kInode] = stats.ino
+
       if (this[kStartPos] === null) {
         // First iteration - nothing has been polled yet
         this[kStartPos] = eof
-        this[kInode] = stats.ino
       } else if (this[kInode] !== stats.ino) {
         // File renamed/rolled
         await this._readRemainderFromFileHandle()


### PR DESCRIPTION
This feature will allow things like being able to tail a
file from the beginning (by passing 0). If `startPos` is
provided, the tailing will begin at that spot in the file.

Semver: minor
Fixes: https://github.com/logdna/tail-file-node/issues/7
Ref: LOG-7789