### PR TITLE
refactor: `start()` should throw if filename doesn't exist

### DIFF
--- a/lib/tail-file.js
+++ b/lib/tail-file.js
@@ -107,12 +107,8 @@ class TailFile extends Readable {
   }
 
   async start() {
-    try {
-      await this._openFile()
-      await this._pollFileForChanges()
-    } catch (err) {
-      return this.quit(err)
-    }
+    await this._openFile()
+    await this._pollFileForChanges()
     return
   }
 

--- a/test/tail-file.js
+++ b/test/tail-file.js
@@ -324,23 +324,14 @@ test('Success: startPos can be provided to start tailing at a given place', (t) 
   })
 })
 
-test('Error: filename provided does not exist (poll error)', (t) => {
-  t.plan(3)
-
-  const tail = new TailFile('THISFILEDOSNOTEXIST', {maxPollFailures: 1})
-    .on('error', (err) => {
-      t.type(err, Error, 'error was emitted')
-      t.match(err, {
-        name: 'Error'
-      , code: 'ENOENT'
-      , path: 'THISFILEDOSNOTEXIST'
-      , message: /no such file or directory/
-      })
-    })
-
-  t.test('Start', async (tt) => {
-    await tail.start()
-  })
+test('Error: filename provided does not exist (throws on start)', async (t) => {
+  const tail = new TailFile('THISFILEDOSNOTEXIST')
+  await t.rejects(tail.start(), {
+    name: 'Error'
+  , code: 'ENOENT'
+  , path: 'THISFILEDOSNOTEXIST'
+  , message: /no such file or directory/
+  }, 'Expected error is thrown')
 })
 
 test('Error: poll error will retry a certain number of times', (t) => {


### PR DESCRIPTION
BREAKING CHANGE: Error handling for `start` is changing.

Since `start` is an `async` function, one would expect to
be able to try/catch it. The original version ran any
failures through the `quit` method, but it's designed to
fail gracefully and work asynchronously by using `'error'`
events. This causes weird flow issues if  `start` is throwing·
because the filename does not exist. This change allows
`start` to simply throw.

Semver: major
Ref: LOG-8030