### PR TITLE
fix: Specify 'r' flag for fs.promises.open

### DIFF
--- a/lib/tail-file.js
+++ b/lib/tail-file.js
@@ -113,7 +113,7 @@ class TailFile extends Readable {
   }
 
   async _openFile() {
-    this[kFileHandle] = await fs.promises.open(this[kFileName])
+    this[kFileHandle] = await fs.promises.open(this[kFileName], 'r')
     return
   }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "streams",
     "tail stream"
   ],
+  "engines": {
+    "node": ">=10.3.0"
+  },
   "bugs": {
     "url": "https://github.com/logdna/tail-file-node/issues"
   },


### PR DESCRIPTION
On older version of node (e.g. 10), the read flags cannot
be `undefined` or it will throw an error.  This change
specifies the 'r' flag, which defaults correctly in later
node versions.  Also, since this package uses for-await-of
loops when reading streams, version >= 10.3.0 is required.
This change specifies an `engines` declaration in the
package.json.

Semver: patch
Fixes: https://github.com/logdna/tail-file-node/issues/10