### PR TITLE
test: Add tap-xunit and flatten results for junit output

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,24 +63,18 @@ pipeline {
                 npm.auth token: "${GITHUB_PACKAGES_TOKEN}"
               }
 
-              sh """
-              npm install
-              """
+              sh 'npm install'
             }
           }
 
           stage('Test') {
             steps {
-              sh 'node -v'
-              sh 'npm -v'
-              sh 'npm test'
+              sh 'npm run test:ci'
             }
 
             post {
               always {
-                sh 'cat .tap-output | ./node_modules/.bin/tap-mocha-reporter xunit > coverage/test.xml'
-
-                junit 'coverage/test.xml'
+                junit checksName: 'Test Results', testResults: 'coverage/*.xml'
 
                 publishHTML target: [
                   allowMissing: false,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A node.js version of unix's `tail -f` command",
   "main": "index.js",
   "scripts": {
+    "test:ci": "tools/test-ci.sh",
     "test": "tap",
     "lint": "eslint ./",
     "pretest": "npm run lint"
@@ -51,7 +52,8 @@
     "eslint": "^7.10.0",
     "eslint-config-logdna": "^2.0.0",
     "husky": "^4.3.0",
-    "tap": "^14.10.7"
+    "tap": "^14.10.7",
+    "tap-xunit": "^2.4.1"
   },
   "tap": {
     "100": true,
@@ -75,7 +77,7 @@
     "files": [
       "test/**/*.js"
     ],
-    "output-file": ".tap-output"
+    "output-file": "coverage/.tap-output"
   },
   "husky": {
     "hooks": {

--- a/tools/test-ci.sh
+++ b/tools/test-ci.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+export PATH="./node_modules/.bin:$PATH"
+
+mkdir -p coverage
+
+npm run test
+
+code=$?
+
+# tap-mocha-reporter is buggy and does not include all test results. Use tap-xunit,
+# however it has a bug with subtests as well.  @isaacs has offered a solution
+# by flattening: https://github.com/aghassemi/tap-xunit/issues/23#issuecomment-520480836
+
+cat coverage/.tap-output | tap-parser -t -f | tap-xunit > coverage/test.xml
+
+exit $code


### PR DESCRIPTION
This change tests tap-xunit as a way to generate a junit
report. tap-xunit does not parse failures on subtests
properly, so flatten them in order to see the full failure
details which are important.

Semver: patch