### PR TITLE
fix: Move default branch to `main` and add contributors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,138 @@
+# Contributor's Code of Conduct
+
+If you contribute to this repo, you agree to abide by this code of conduct for
+this community.
+
+We abide by the
+[Contributor Covenant Code of Conduct, 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
+It is reproduced below for ease of use.
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[opensource@logdna.com](mailto:opensource@logdna.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,16 +5,17 @@
 We use a fork-and-PR process, also known as a triangular workflow. This process
 is fairly common in open-source projects. Here's the basic workflow:
 
-1. Fork the repo to create your own. This repo is called the origin repo.
-2. Work your changes on a branch in your repo.
-3. Submit your changes as a PR against the upstream repo.
-4. Maintainers review your changes. If they ask for changes, you work on your
-    origin repo's branch. Otherwise, the branch is merged to upstream's main
-    trunk.
+1. Fork the upstream repo to create your own repo. This repo is called the origin repo.
+2. Clone the origin repo to create a working directory on your local machine.
+3. Work your changes on a branch in your working directory, then add, commit, and push your work to your origin repo.
+4. Submit your changes as a PR against the upstream repo. You can use the upstream repo UI to do this.
+5. Maintainers review your changes. If they ask for changes, you work on your
+   origin repo's branch and then submit another PR. Otherwise, if no changes are made,
+   then the branch with your PR is merged to upstream's main trunk, the main branch.
 
 When you work in a triangular workflow, you have the upstream repo, the origin
-repo, and then your local clone of the origin repo. You fetch from upstream to
-local, push from local to origin, and then do a PR from origin to
+repo, and then your working directory (the clone of the origin repo). You do
+a `git fetch` from upstream to local, push from local to origin, and then do a PR from origin to
 upstream&mdash;a triangle.
 
 If this workflow is too much to understand to start, that's ok! You can use
@@ -22,15 +23,22 @@ GitHub's UI to make a change, which is autoset to do most of this process for
 you. We just want you to be aware of how the entire process works before
 proposing a change.
 
+Thank you for your contributions; we appreciate you!
+
 ## License
 
-Note that we use a standard MIT license on this repo.
+Note that we use a standard [MIT](./LICENSE) license on this repo.
 
-## Issues and Bugs
+## Coding style
 
-Please use GitHub Issues to submit issues and bugs. Also, please open an issue
-before opening a PR to discuss any changes you think need to be made.
+Code style is enforced by [eslint][]. Linting is applied CI builds when a pull request
+is made. The rule set being enforced is provided by [eslint-config-logdna][]
 
 ## Questions?
 
-Reach out in the GitHub Issues, or email us at `opensource at logdna.com`.
+The easiest way to get our attention is to comment on an existing, or open a new
+[issue][].
+
+[eslint]: https://eslint.org
+[eslint-config-logdna]: https://github.com/logdna/eslint-config-logdna
+[issue]: https://github.com/logdna/eslint-config-logdna/issues

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ library 'magic-butler-catalogue'
 def PROJECT_NAME = "tail-file-node"
 def REPO = "logdna/${PROJECT_NAME}"
 def TRIGGER_PATTERN = ".*@logdnabot.*"
+def DEFAULT_BRANCH = 'main'
 
 pipeline {
   agent none
@@ -95,7 +96,7 @@ pipeline {
       when {
         beforeAgent true
         not {
-          branch 'master'
+          branch DEFAULT_BRANCH
         }
       }
 
@@ -120,7 +121,7 @@ pipeline {
           token: "${GITHUB_PACKAGES_TOKEN}"
         , dry: true
         , repo: REPO
-        , branch: "master"
+        , branch: DEFAULT_BRANCH
         )
       }
     }
@@ -128,7 +129,7 @@ pipeline {
     stage('Release') {
       when {
         beforeAgent true
-        branch 'master'
+        branch DEFAULT_BRANCH
       }
 
       agent {
@@ -156,7 +157,7 @@ pipeline {
         , dry: false
         , repo: REPO
         , NPM_PUBLISH_TOKEN: "${NPM_PUBLISH_TOKEN}"
-        , branch: "master"
+        , branch: DEFAULT_BRANCH
         )
       }
     }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Coverage Status](https://coveralls.io/repos/github/logdna/tail-file-node/badge.svg?branch=master)](https://coveralls.io/github/logdna/tail-file-node?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/logdna/tail-file-node/badge.svg?branch=main)](https://coveralls.io/github/logdna/tail-file-node?branch=main)
 
 # TailFile
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,28 @@
     "url": "https://github.com/logdna/tail-file-node"
   },
   "homepage": "https://github.com/logdna/tail-file-node",
-  "author": "LogDNA, Inc.",
+  "author": {
+    "name": "LogDNA, Inc.",
+    "email": "help@logdna.com"
+  },
+  "contributors": [
+    {
+      "name": "Darin Spivey",
+      "email": "darin.spivey@logdna.com"
+    },
+    {
+      "name": "Jakub Jirutka",
+      "email": "jakub@jirutka.cz"
+    },
+    {
+      "name": "Ryan Mottley",
+      "email": "ryan.mottley@logdna.com"
+    },
+    {
+      "name": "Laura Santamaria",
+      "email": "dev@nimbinatus.com"
+    }
+  ],
   "license": "SEE LICENSE IN LICENSE",
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
This changes the main branch to `main` instead of `master`
while also adding contributing guidelines docs and a
`contributors` section to `package.json`.

Semver: patch