### PR TITLE
feat: Include `lastReadPosition` in the `flush` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,17 @@ superclass. Additionally, it will emit the following custom events.
 
 ### Event: `'flush'`
 
-* No payload
+* [`<Object>`][]
+  * `lastReadPosition` [`<Number>`][] - The current file position at `flush` time
 
 This event is emitted when the underlying stream is done being read.
 If backpressure is in effect, then `_read()` may be called multiple
 times until it's flushed, so this event signals the end of the process.
 It is used primarily in shutdown to make sure the data is exhausted,
-and there should be no reason for the user to listen to this event.
+but users may listen for this event if the relative "read position" in the
+file is of interest.  For example, the `lastReadPosition` may be persisted to memory
+or database for resuming `tail-file` on a separate execution without missing
+any lines or duplicating them.
 
 ### Event: `'renamed'`
 

--- a/lib/tail-file.d.ts
+++ b/lib/tail-file.d.ts
@@ -26,6 +26,13 @@ interface RetryEventPayload extends EventPayload {
   attempts: number
 }
 
+interface FlushEventPayload {
+  /**
+   * The `lastReadPosition` represents the `startPos` value at the time of flushing
+   */
+  lastReadPosition: number
+}
+
 interface TailErrorEventPayload {
   /**
    * The error message as written by `TailFile`.
@@ -59,7 +66,7 @@ interface ReadableEvents {
 }
 
 interface TailFileEvents extends ReadableEvents {
-  flush: () => void
+  flush: (payload: FlushEventPayload) => void
   renamed: (payload: EventPayload) => void
   retry: (payload: RetryEventPayload) => void
   tail_error: (payload: TailErrorEventPayload) => void

--- a/lib/tail-file.js
+++ b/lib/tail-file.js
@@ -150,7 +150,9 @@ class TailFile extends Readable {
       this._scheduleTimer(this[kPollFileIntervalMs])
     }
     this[kStream] = null
-    setImmediate(this.emit.bind(this), 'flush')
+    setImmediate(this.emit.bind(this), 'flush', {
+      lastReadPosition: this[kStartPos]
+    })
     return
   }
 
@@ -209,7 +211,9 @@ class TailFile extends Readable {
         await this._streamFileChanges()
         if (this[kStream]) return // Pause polling if backpressure is on
       } else {
-        setImmediate(this.emit.bind(this), 'flush')
+        setImmediate(this.emit.bind(this), 'flush', {
+          lastReadPosition: this[kStartPos]
+        })
       }
 
       this._scheduleTimer(this[kPollFileIntervalMs])

--- a/test/tail-file.js
+++ b/test/tail-file.js
@@ -320,6 +320,10 @@ test('Success: Filehandle close NOOPs on error', async (t) => {
   // Force an error for FH close.  NOTE: this mock is only needed for node 14
   // which does NOT throw an error as in 10 and 12.  Keeps converage at 100% for
   // the matrix.
+
+  const realFH = tail[symbols.fileHandle]
+  await realFH.close() // Prevent GC error from not closing this for real
+
   tail[symbols.fileHandle] = {
     close: async () => {
       throw new Error('NOPE')


### PR DESCRIPTION
Users will sometimes want to track the current position
that `tail-file` is reading from. This could be useful
between two separate `tail-file` instances on the same
file. Since the `flush` event represents being "caught up"
when reading from the source file, emit the `lastReadPosition`
in the `flush` event payload for informative purposes.

Semver: minor
Fixes: https://github.com/logdna/tail-file-node/issues/19