### PR TITLE
fix(deps): Fix missing release section in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,12 @@
     "url": "https://github.com/logdna/tail-file-node/issues"
   },
   "private": false,
+  "release": {
+    "extends": "semantic-release-config-logdna",
+    "branches": [
+      "main"
+    ]
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
`semantic-release-config-logdna` was recently added to support
releasing via semantic-release. However, the `release` section
was left out and the previous release failed. This will fix it
and release that major version that is pending.

Fixes: #28