### PR TITLE
fix(pkg): Set `license` in `package.json` accurately

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
       "email": "dev@nimbinatus.com"
     }
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "eslintConfig": {
     "root": true,
     "ignorePatterns": [


### PR DESCRIPTION
Certain tooling may try to take advantage of the `license` field in `package.json`.  Since this is an MIT licensed product, reflect that in the license field.

Fixes: #43