### PR TITLE
docs: Fix docs on return value of `quit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ that data will not flow through the stream [until it's consumed][reading modes].
 
 ### `tail.quit()`
 
-* Returns: `undefined`
+* Returns: [`<Promise>`][] - Resolves after `flush` is called and streams are closed.
 * Emits: [`close`](#event-any-readable-event) when the parent `Readstream` is ended.
 
 This function calls `flush`, then closes all streams and exits cleanly.  The parent `TailFile` stream will be


### PR DESCRIPTION
Being an [async function](https://github.com/logdna/tail-file-node/blob/0ebab58687530431b60a9901ce08fe6417448dc0/lib/tail-file.js#L293) It always returns a `Promise`. I also checked the typescript definitions and they were already correct.