### PR TITLE
fix(ci): Skip release:dry for forks and call commitlint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,7 +113,10 @@ pipeline {
         script {
           sh "mkdir -p ${NPM_CONFIG_CACHE}"
           sh 'npm install'
-          sh "npm run release:dry"
+          sh 'npm run commitlint'
+          if (!(env.CHANGE_FORK ==~ /.+/)) {
+            sh "npm run release:dry"
+          }
         }
       }
     }


### PR DESCRIPTION
When public forks open PRs, skip the release test since `branches` will be null due to `CHANGE_BRANCH` and `BRANCH_NAME` being null.

Also, the `commitlint` script was not being called. Add it.

Fixes: #46